### PR TITLE
add duplicate key error handle

### DIFF
--- a/lib/mongoStore.js
+++ b/lib/mongoStore.js
@@ -146,6 +146,10 @@ MongoStore.prototype.incr = function(key, callback) {
 			this.pass(expressRateRecord.counter, expressRateRecord.expirationDate);
 		},
 		function(err, counter, expirationDate) {
+			if (err && err.code === 11000) {
+				return self.incr(key, callback);
+			}
+
 			if (err) {
 				self.errorHandler(err);
 			}

--- a/lib/mongoStore.js
+++ b/lib/mongoStore.js
@@ -146,6 +146,7 @@ MongoStore.prototype.incr = function(key, callback) {
 			this.pass(expressRateRecord.counter, expressRateRecord.expirationDate);
 		},
 		function(err, counter, expirationDate) {
+			// call function again in case of duplicate key error
 			if (err && err.code === 11000) {
 				return self.incr(key, callback);
 			}

--- a/test/mongoStore/incr/utils.js
+++ b/test/mongoStore/incr/utils.js
@@ -48,7 +48,8 @@ exports.getMocks = function(testData) {
 				_getCollection: sinon.stub().callsArgWithAsync(
 					0, null, collectionMock
 				),
-				errorHandler: sinon.stub().returns()
+				errorHandler: sinon.stub().returns(),
+				incr: sinon.stub().callsArgWithAsync(1)
 			},
 			collection: collectionMock
 		}

--- a/test/mongoStore/incr/withFindOndAndUpdateDuplicateKeyError.js
+++ b/test/mongoStore/incr/withFindOndAndUpdateDuplicateKeyError.js
@@ -1,16 +1,19 @@
 'use strict';
 
 var expect = require('expect.js');
+var Steppy = require('twostep').Steppy;
 var rewire = require('rewire');
 var _ = require('underscore');
 var testUtils = require('./utils');
 
 var MongoStore = rewire('../../../lib/mongoStore');
 
-var describeTitle = 'MongoStore.prototype.incr with resetExpireDateOnChange';
+var describeTitle = 'MongoStore.prototype.incr with ' +
+	'findOneAndUpdate duplicate key error';
 describe(describeTitle, function() {
 	var testData = testUtils.getTestData();
-	testData.mongoStoreContext.resetExpireDateOnChange = true;
+	testData.findOneAndUpdateError = new Error();
+	testData.findOneAndUpdateError.code = 11000;
 
 	var mocks = testUtils.getMocks(testData);
 
@@ -22,25 +25,19 @@ describe(describeTitle, function() {
 		);
 	});
 
-	it('should return counter and expirationDate', function(done) {
-		MongoStore.prototype.incr.call(
-			_({}).extend(
-				testData.mongoStoreContext,
-				mocks._dynamic.mongoStoreContext
-			),
-			testData.key,
-			function(err, counter, expirationDate) {
-				revertMocks();
-
-				expect(counter).eql(
-					testData.collection.findOneAndUpdateResult.value.counter
+	it('should be ok', function(done) {
+		Steppy(
+			function() {
+				MongoStore.prototype.incr.call(
+					_({}).extend(
+						testData.mongoStoreContext,
+						mocks._dynamic.mongoStoreContext
+					),
+					testData.key,
+					this.slot()
 				);
-				expect(expirationDate).eql(
-					testData.collection.findOneAndUpdateResult.value.expirationDate
-				);
-
-				done();
-			}
+			},
+			done
 		);
 	});
 
@@ -91,7 +88,7 @@ describe(describeTitle, function() {
 				{_id: testData.key},
 				{
 					$inc: {counter: 1},
-					$set: {
+					$setOnInsert: {
 						expirationDate: testData.DateResult
 					}
 				},
@@ -107,10 +104,20 @@ describe(describeTitle, function() {
 		}
 	);
 
-	it('self.incr should not be called', function() {
+	it('self.incr should be called', function() {
+		expect(mocks._dynamic.mongoStoreContext.incr.callCount).eql(1);
+
+		var incrArgs = mocks._dynamic.mongoStoreContext.incr.args[0];
+
 		expect(
-			mocks._dynamic.mongoStoreContext.incr.callCount
-		).eql(0);
+			_(incrArgs).initial()
+		).eql([
+			testData.key
+		]);
+
+		expect(
+			_(incrArgs).last()
+		).a('function');
 	});
 
 	it('errorHandler should not be called', function() {

--- a/test/mongoStore/incr/withFindOneAndUpdateError.js
+++ b/test/mongoStore/incr/withFindOneAndUpdateError.js
@@ -109,6 +109,12 @@ describe(describeTitle, function() {
 		}
 	);
 
+	it('self.incr should not be called', function() {
+		expect(
+			mocks._dynamic.mongoStoreContext.incr.callCount
+		).eql(0);
+	});
+
 	it('errorHandler should be called with error', function() {
 		expect(
 			mocks._dynamic.mongoStoreContext.errorHandler.callCount

--- a/test/mongoStore/incr/withoutResetExpireDateOnChange.js
+++ b/test/mongoStore/incr/withoutResetExpireDateOnChange.js
@@ -107,6 +107,12 @@ describe(describeTitle, function() {
 		}
 	);
 
+	it('self.incr should not be called', function() {
+		expect(
+			mocks._dynamic.mongoStoreContext.incr.callCount
+		).eql(0);
+	});
+
 	it('errorHandler should not be called', function() {
 		expect(
 			mocks._dynamic.mongoStoreContext.errorHandler.callCount


### PR DESCRIPTION
Such duplicate key error handling prevents duplicate key error when doing upserts in parallel (mongodb behaviour in this case described [here](https://jira.mongodb.org/browse/SERVER-14322)).