### PR TITLE
fix/useUnifiedTopology

### DIFF
--- a/lib/mongoStore.js
+++ b/lib/mongoStore.js
@@ -44,7 +44,8 @@ MongoStore.prototype._createCollection = function(callback) {
 	Steppy(
 		function() {
 			var connectOptions = {
-				useNewUrlParser: true
+				useNewUrlParser: true,
+				useUnifiedTopology: true
 			};
 
 			if (self.dbOptions.user && self.dbOptions.password) {


### PR DESCRIPTION
https://mongoosejs.com/docs/deprecations.html

By default, mongoose.connect() will print out the below warning:

DeprecationWarning: current Server Discovery and Monitoring engine is
deprecated, and will be removed in a future version. To use the new Server
Discover and Monitoring engine, pass option { useUnifiedTopology: true } to
the MongoClient constructor.
Mongoose 5.7 uses MongoDB driver 3.3.x, which introduced a significant refactor of how it handles monitoring all the servers in a replica set or sharded cluster. In MongoDB parlance, this is known as server discovery and monitoring.

To opt in to using the new topology engine, use the below line:

mongoose.set('useUnifiedTopology', true);