### PR TITLE
Use unified mongodb topology

### DIFF
--- a/lib/mongoStore.js
+++ b/lib/mongoStore.js
@@ -44,7 +44,8 @@ MongoStore.prototype._createCollection = function(callback) {
 	Steppy(
 		function() {
 			var connectOptions = {
-				useNewUrlParser: true
+				useNewUrlParser: true,
+				useUnifiedTopology: true
 			};
 
 			if (self.dbOptions.user && self.dbOptions.password) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "twostep": "0.4.2",
     "underscore": "1.9.1",
-    "mongodb": "3.x.x"
+    "mongodb": ">= 3.3.4 < 4.0.0"
   },
   "devDependencies": {
     "expect.js": "0.3.1",

--- a/test/mongoStore/_createCollection/withSuitableParams.js
+++ b/test/mongoStore/_createCollection/withSuitableParams.js
@@ -52,7 +52,10 @@ describe(describeTitle, function() {
 			_(MongoClientConnectArgs).initial()
 		).eql([
 			testData.mongoStoreContext.dbOptions.uri,
-			{useNewUrlParser: true}
+			{
+				useNewUrlParser: true,
+				useUnifiedTopology: true
+			}
 		]);
 
 		expect(

--- a/test/mongoStore/_createCollection/withUserAndPassword.js
+++ b/test/mongoStore/_createCollection/withUserAndPassword.js
@@ -56,6 +56,7 @@ describe(describeTitle, function() {
 			testData.mongoStoreContext.dbOptions.uri,
 			{
 				useNewUrlParser: true,
+				useUnifiedTopology: true,
 				authSource: 'testDbName',
 				auth: {
 					user: testData.mongoStoreContext.dbOptions.user,

--- a/test/mongoStore/_createCollection/withUserAndPasswordAndAuthSource.js
+++ b/test/mongoStore/_createCollection/withUserAndPasswordAndAuthSource.js
@@ -57,6 +57,7 @@ describe(describeTitle, function() {
 			testData.mongoStoreContext.dbOptions.uri,
 			{
 				useNewUrlParser: true,
+				useUnifiedTopology: true,
 				authSource: testData.mongoStoreContext.dbOptions.authSource,
 				auth: {
 					user: testData.mongoStoreContext.dbOptions.user,


### PR DESCRIPTION
Use unified topology (was introduced in [mongodb 3.2.1](https://github.com/mongodb/node-mongodb-native/releases/tag/v3.2.1)) with mongodb driver which prevents annoying warning on `MongoClient.connect`:

```
DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
```

Unfortunately according to [this](https://github.com/Automattic/mongoose/issues/8180) and [that](https://jira.mongodb.org/browse/NODE-2313) using unified topology could break connection to mongodb when using driver older then [3.3.4](https://github.com/mongodb/node-mongodb-native/releases/tag/v3.3.4). To deal with it `rate-limit-mongo` will require mongodb 3.3.4 or newer.