### PR TITLE
Refactor: Use findOneAndUpdate with returnDocument

### DIFF
--- a/lib/mongoStore.js
+++ b/lib/mongoStore.js
@@ -147,7 +147,7 @@ MongoStore.prototype.incr = function(key, callback) {
 				modifier,
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				},
 				this.slot()
 			);
@@ -201,7 +201,7 @@ MongoStore.prototype.decrement = function(key) {
 				modifier,
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				},
 				this.slot()
 			);

--- a/package-lock.json
+++ b/package-lock.json
@@ -472,6 +472,58 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -760,8 +812,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -809,6 +860,11 @@
       "requires": {
         "strip-bom": "^4.0.0"
       }
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "diff": {
       "version": "3.5.0",
@@ -1315,8 +1371,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1805,12 +1860,14 @@
       }
     },
     "mongodb": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.4.tgz",
-      "integrity": "sha512-6fmHu3FJTpeZxacJcfjUGIP3BSteG0l2cxLkSrf1nnnS1OrlnVGiP9P/wAC4aB6dM6H4vQ2io8YDjkuPkje7AA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.0.tgz",
+      "integrity": "sha512-JOAYjT9WYeRFkIP6XtDidAr3qvpfLRJhT2iokRWWH0tgqCQr9kmSfOJBZ3Ry0E5A3EqKxVPVhN3MV8Gn03o7pA==",
       "requires": {
-        "bson": "^1.1.1",
-        "require_optional": "^1.0.1",
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
@@ -1928,6 +1985,14 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "optional-require": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.7.tgz",
+      "integrity": "sha512-cIeRZocXsZnZYn+SevbtSqNlLbeoS4mLzuNn4fvXRMDRNhTGg0sxuKXl0FnZCtnew85LorNxIbZp5OeliILhMw==",
+      "requires": {
+        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -2058,8 +2123,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -2109,6 +2173,11 @@
         "es6-error": "^4.0.1"
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2139,15 +2208,6 @@
         }
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -2156,11 +2216,6 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -2215,9 +2270,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2237,7 +2292,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2517,8 +2573,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mongodb"
   ],
   "dependencies": {
-    "mongodb": ">= 3.3.4 < 4.0.0",
+    "mongodb": "^3.6.7",
     "twostep": "0.4.2",
     "underscore": "1.12.1"
   },

--- a/test/mongoStore/decrement/withFindOneAndUpdateError.js
+++ b/test/mongoStore/decrement/withFindOneAndUpdateError.js
@@ -97,7 +97,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/decrement/withResetExpireDateOnCange.js
+++ b/test/mongoStore/decrement/withResetExpireDateOnCange.js
@@ -93,7 +93,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/decrement/withoutResetExpireDateOnChange.js
+++ b/test/mongoStore/decrement/withoutResetExpireDateOnChange.js
@@ -93,7 +93,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/incr/withFindOndAndUpdateDuplicateKeyError.js
+++ b/test/mongoStore/incr/withFindOndAndUpdateDuplicateKeyError.js
@@ -94,7 +94,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/incr/withFindOneAndUpdateError.js
+++ b/test/mongoStore/incr/withFindOneAndUpdateError.js
@@ -99,7 +99,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/incr/withResetExpireDateOnCange.js
+++ b/test/mongoStore/incr/withResetExpireDateOnCange.js
@@ -97,7 +97,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 

--- a/test/mongoStore/incr/withoutResetExpireDateOnChange.js
+++ b/test/mongoStore/incr/withoutResetExpireDateOnChange.js
@@ -97,7 +97,7 @@ describe(describeTitle, function() {
 				},
 				{
 					upsert: true,
-					returnOriginal: false
+					returnDocument: 'after'
 				}
 			]);
 


### PR DESCRIPTION
This PR replaces findOneAndUpdate  `returnOriginal` with `returnDocument` to avoid a MongoDB driver deprecation warning:

```
(node:70353) [MONGODB DRIVER] DeprecationWarning: collection.findOneAndUpdate option [returnOriginal] is deprecated and will be removed in a later version.
```

It should fix https://github.com/2do2go/rate-limit-mongo/issues/35